### PR TITLE
[Feat] #5 - Font와 LineHeight를 함께 적용할 수 있는 ViewModifier 추가

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Colors.swift
+++ b/Projects/Shared/DesignSystem/Sources/Colors.swift
@@ -45,7 +45,7 @@ public extension ShapeStyle where Self == Color {
   static var greyScale950: Color { .init(asset: SharedDesignSystemAsset.Colors.greyScale950) }
 }
 
-public enum Colors {
+fileprivate enum Colors {
   case primary050
   case primary100
   case primary200

--- a/Projects/Shared/DesignSystem/Sources/Extensions/View+notoSans.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extensions/View+notoSans.swift
@@ -1,0 +1,30 @@
+//
+//  View+OKFont.swift
+//  SharedDesignSystem
+//
+//  Created by 홍은표 on 8/6/24.
+//
+
+import Foundation
+import SwiftUI
+
+public extension View {
+  func notoSans(_ token: Font.Token) -> some View {
+    self.modifier(FontAndLineHeightModifier(typography: token.typography))
+  }
+}
+
+private struct FontAndLineHeightModifier: ViewModifier {
+  private let typography: Typographyable
+  
+  fileprivate init(typography: Typographyable) {
+    self.typography = typography
+  }
+  
+  fileprivate func body(content: Content) -> some View {
+    content
+      .font(Font(typography.font))
+      .lineSpacing(typography.lineHeight - typography.font.lineHeight)
+      .padding(.vertical, (typography.lineHeight - typography.font.lineHeight) / 2)
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Font.swift
+++ b/Projects/Shared/DesignSystem/Sources/Font.swift
@@ -7,146 +7,100 @@
 
 import SwiftUI
 
-public extension Font {
-  static func notoSans(_ type: FontToken) -> Font {
-    type.font
-  }
-  
-  static func notoSans(size fontSize: CGFloat, type: FontType) -> Font {
-    return .custom("\(type.name)", size: fontSize)
-  }
+protocol Typographyable {
+  var font: UIFont { get }
+  var lineHeight: CGFloat { get }
 }
 
 public extension Font {
-  enum FontType {
-    case bold
-    case regular
+  struct NotoSans: Typographyable {
+    let size: CGFloat
+    let lineHeight: CGFloat
+    let weight: FontWeight
     
-    var name : String {
-      switch self {
-      case .bold:
-        return "NotoSans-Bold"
-      case .regular:
-        return "NotoSans-Regular"
+    var font: UIFont {
+      UIFont(name: weight.name, size: size)!
+    }
+    
+    enum FontWeight {
+      case bold
+      case regular
+      
+      var name: String {
+        switch self {
+        case .bold:
+          return "NotoSans-Bold"
+        case .regular:
+          return "NotoSans-Regular"
+        }
       }
     }
   }
   
-  enum FontToken {
-    
-    // MARK: - title
-    
-    case display_05
-    case display_04
-    case display_03
-    case display_02
-    case display_01
+  enum Token {
+    case display_5
+    case display_4
+    case display_3
+    case display_2
+    case display_1
     case headline
-    case subhead_04
-    case subhead_03
-    case subhead_long_03
-    case subhead_02
-    case subhead_long_02
-    case subhead_01
+    case subhead_4
+    case subhead_3
+    case subhead_long_3
+    case subhead_2
+    case subhead_long_2
+    case subhead_1
     case nav_title_active
-    
-    // MARK: - body
-    
-    case body_03
-    case body_02
-    case body_long_02
-    case body_01
-    case body_long_01
+    case body_3
+    case body_2
+    case body_long_2
+    case body_1
+    case body_long_1
     case caption
     case nav_title_inactive
     
-    var font: Font {
+    var typography: Typographyable {
       switch self {
-      case .display_05:
-        return .notoSans(size: 40, type: .bold)
-      case .display_04:
-        return .notoSans(size: 36, type: .bold)
-      case .display_03:
-        return .notoSans(size: 32, type: .bold)
-      case .display_02:
-        return .notoSans(size: 28, type: .bold)
-      case .display_01:
-        return .notoSans(size: 24, type: .bold)
+      case .display_5:
+        return NotoSans(size: 40, lineHeight: 52, weight: .bold)
+      case .display_4:
+        return NotoSans(size: 36, lineHeight: 46, weight: .bold)
+      case .display_3:
+        return NotoSans(size: 32, lineHeight: 42, weight: .bold)
+      case .display_2:
+        return NotoSans(size: 28, lineHeight: 38, weight: .bold)
+      case .display_1:
+        return NotoSans(size: 24, lineHeight: 34, weight: .bold)
       case .headline:
-        return .notoSans(size: 20, type: .bold)
-      case .subhead_04:
-        return .notoSans(size: 18, type: .bold)
-      case .subhead_03:
-        return .notoSans(size: 16, type: .bold)
-      case .subhead_long_03:
-        return .notoSans(size: 16, type: .bold)
-      case .subhead_02:
-        return .notoSans(size: 14, type: .bold)
-      case .subhead_long_02:
-        return .notoSans(size: 14, type: .bold)
-      case .subhead_01:
-        return .notoSans(size: 12, type: .bold)
+        return NotoSans(size: 20, lineHeight: 28, weight: .bold)
+      case .subhead_4:
+        return NotoSans(size: 18, lineHeight: 24, weight: .bold)
+      case .subhead_3:
+        return NotoSans(size: 16, lineHeight: 22, weight: .bold)
+      case .subhead_long_3:
+        return NotoSans(size: 16, lineHeight: 28, weight: .bold)
+      case .subhead_2:
+        return NotoSans(size: 14, lineHeight: 20, weight: .bold)
+      case .subhead_long_2:
+        return NotoSans(size: 14, lineHeight: 24, weight: .bold)
+      case .subhead_1:
+        return NotoSans(size: 12, lineHeight: 18, weight: .bold)
       case .nav_title_active:
-        return .notoSans(size: 10, type: .bold)
-      case .body_03:
-        return .notoSans(size: 18, type: .regular)
-      case .body_02:
-        return .notoSans(size: 16, type: .regular)
-      case .body_long_02:
-        return .notoSans(size: 16, type: .regular)
-      case .body_01:
-        return .notoSans(size: 14, type: .regular)
-      case .body_long_01:
-        return .notoSans(size: 14, type: .regular)
+        return NotoSans(size: 10, lineHeight: 16, weight: .bold)
+      case .body_3:
+        return NotoSans(size: 18, lineHeight: 24, weight: .regular)
+      case .body_2:
+        return NotoSans(size: 16, lineHeight: 24, weight: .regular)
+      case .body_long_2:
+        return NotoSans(size: 16, lineHeight: 28, weight: .regular)
+      case .body_1:
+        return NotoSans(size: 14, lineHeight: 20, weight: .regular)
+      case .body_long_1:
+        return NotoSans(size: 14, lineHeight: 24, weight: .regular)
       case .caption:
-        return .notoSans(size: 12, type: .regular)
+        return NotoSans(size: 12, lineHeight: 18, weight: .regular)
       case .nav_title_inactive:
-        return .notoSans(size: 10, type: .regular)
-      }
-    }
-    
-    var lineHeight: CGFloat {
-      switch self {
-      case .display_05:
-        return 52
-      case .display_04:
-        return 46
-      case .display_03:
-        return 42
-      case .display_02:
-        return 38
-      case .display_01:
-        return 34
-      case .headline:
-        return 28
-      case .subhead_04:
-        return 24
-      case .subhead_03:
-        return 22
-      case .subhead_long_03:
-        return 28
-      case .subhead_02:
-        return 20
-      case .subhead_long_02:
-        return 24
-      case .subhead_01:
-        return 18
-      case .nav_title_active:
-        return 16
-      case .body_03:
-        return 24
-      case .body_02:
-        return 24
-      case .body_long_02:
-        return 28
-      case .body_01:
-        return 20
-      case .body_long_01:
-        return 24
-      case .caption:
-        return 18
-      case .nav_title_inactive:
-        return 16
+        return NotoSans(size: 10, lineHeight: 16, weight: .regular)
       }
     }
   }


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #5

## 🛠️ 작업한 내용
- Font와 LineHeight를 함께 적용할 수 있는 ViewModifier를 추가했습니다!
- Token들 중에서 display_03와 같이 의미없는 숫자 0이 들어간 부분들은 제거했습니다.
- 작업하다보니 OCP 적용하고 싶은 병이 걸려버려서 작업 시간이 길어져버렸습니다 😢 (만들고보니 폰트 종류가 한개라 별 의미 없었네요..)

## 📸 스크린샷
|    1    |   2   |
| :-------------: | :----------: |
|  ![Simulator Screenshot - iPhone 15 Pro - 2024-08-09 at 01 41 32](https://github.com/user-attachments/assets/fba55068-522a-41f0-9704-98883c527a68) |  ![Simulator Screenshot - iPhone 15 Pro - 2024-08-09 at 01 41 34](https://github.com/user-attachments/assets/d05a04fc-e658-43d4-ae7c-9fe2e7596866) |

## 🚨 참고 사항
아래처럼 사용합니다.
```swift
VStack {
  Text("내용")
    .notoSans(.caption)
  
  Text("내용")
    .notoSans(.subhead_4)
}
```

보셨을 때 뭔가 뭔가 이상한 코드가 있다던가 궁금하신 점 있으시면 말씀해주세요!
