### PR TITLE
#30 - 홈 아티클 클릭 시 웹뷰로 이동 구현

### DIFF
--- a/Projects/Core/Domain/Sources/Models/Article.swift
+++ b/Projects/Core/Domain/Sources/Models/Article.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Article: Decodable, Identifiable {
+public struct Article: Decodable, Identifiable, Equatable {
   public let id: String
   public let title: String
   public let category: String

--- a/Projects/Feature/Home/Sources/Home/Article/HomeArticleWebView.swift
+++ b/Projects/Feature/Home/Sources/Home/Article/HomeArticleWebView.swift
@@ -1,0 +1,39 @@
+//
+//  HomeArticleWebView.swift
+//  FeatureHome
+//
+//  Created by 현수빈 on 9/25/24.
+//
+
+import SwiftUI
+
+import CoreDomain
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+struct HomeArticleWebView: View {
+  @Bindable private var store: StoreOf<HomeStore>
+  @State private var showShareSheet: Bool = false
+  private let article: Article
+  
+  init(store: StoreOf<HomeStore>, article: Article) {
+    self.store = store
+    self.article = article
+  }
+  
+  var body: some View {
+    VStack {
+      TopArticleNavigation(
+        title: article.title,
+        url: article.url,
+        leftAction: {
+          store.send(.didTapArticleExitButton)
+        }
+      )
+      .padding()
+      WebViewRepresentable(url: article.url)
+    }
+    
+  }
+}

--- a/Projects/Feature/Home/Sources/Home/HomeStore.swift
+++ b/Projects/Feature/Home/Sources/Home/HomeStore.swift
@@ -19,14 +19,18 @@ public struct HomeStore {
   public struct State {
     @Shared(.userInfo) var userInfo: UserInfo?
     var articles: [Article] = []
+    var selectedArticle: Article?
     public init() {}
   }
   
-  public enum Action {
+  public enum Action: BindableAction {
+    case binding(BindingAction<State>)
     case onAppear
     case didTapAppendFolderButton
     case onPresentChat
     case fetchArticles(TaskResult<[Article]>)
+    case didTapArticle(Article)
+    case didTapArticleExitButton
   }
   
   public init() {}
@@ -34,6 +38,8 @@ public struct HomeStore {
   @Dependency(HomeAPIClient.self) var homeAPIClient
   
   public var body: some ReducerOf<Self> {
+    BindingReducer()
+    
     Reduce { state, action in
       switch action {
       case .onAppear:
@@ -54,6 +60,12 @@ public struct HomeStore {
         state.articles = Array(aritlces.prefix(3))
         return .none
       case .fetchArticles(.failure(let error)):
+        return .none
+      case .didTapArticle(let article):
+        state.selectedArticle = article
+        return .none
+      case .didTapArticleExitButton:
+        state.selectedArticle = .none
         return .none
       default:
         return .none

--- a/Projects/Feature/Home/Sources/Home/HomeView.swift
+++ b/Projects/Feature/Home/Sources/Home/HomeView.swift
@@ -9,7 +9,6 @@ import Foundation
 import SwiftUI
 
 import SharedDesignSystem
-import SharedUtils
 
 import ComposableArchitecture
 
@@ -33,6 +32,12 @@ struct HomeView: View {
     }
     .onAppear {
       store.send(.onAppear)
+    }
+    .fullScreenCover(item: $store.selectedArticle) { article in
+      HomeArticleWebView(
+        store: store,
+        article: article
+      )
     }
   }
   
@@ -104,14 +109,18 @@ struct HomeView: View {
       )
       
       ForEach(store.articles) { article in
-        ArticleCellView(
-          thumbnail: { ThumbnailImage(urlString: article.thumbnailURL) },
-          title: article.title,
-          category: article.category,
-          platform: article.platform,
-          postDate: article.postDate.formatted(using: .shortForm),
-          url: article.url
-        )
+        Button(action: {
+          store.send(.didTapArticle(article))
+        } ) {
+          ArticleCellView(
+            thumbnail: { ThumbnailImage(urlString: article.thumbnailURL) },
+            title: article.title,
+            category: article.category,
+            platform: article.platform,
+            postDate: article.postDate.formatted(using: .shortForm),
+            url: article.url
+          )
+        }
       }
     }
   }

--- a/Projects/Feature/Home/Sources/Home/Views/HomeArticleWebView.swift
+++ b/Projects/Feature/Home/Sources/Home/Views/HomeArticleWebView.swift
@@ -1,0 +1,39 @@
+//
+//  HomeArticleWebView.swift
+//  FeatureHome
+//
+//  Created by 현수빈 on 9/25/24.
+//
+
+import SwiftUI
+
+import CoreDomain
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+struct HomeArticleWebView: View {
+  @Bindable private var store: StoreOf<HomeStore>
+  @State private var showShareSheet: Bool = false
+  private let article: Article
+  
+  init(store: StoreOf<HomeStore>, article: Article) {
+    self.store = store
+    self.article = article
+  }
+  
+  var body: some View {
+    VStack {
+      TopArticleNavigation(
+        title: article.title,
+        url: article.url,
+        leftAction: {
+          store.send(.didTapArticleExitButton)
+        }
+      )
+      .padding()
+      WebViewRepresentable(url: article.url)
+    }
+    
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Cells/Article/ArticleCellView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Cells/Article/ArticleCellView.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 
+import SharedUtils
 
 public struct ArticleCellView<Thumbnail: View>: View {
   private let thumbnailImage: Thumbnail
@@ -34,53 +35,49 @@ public struct ArticleCellView<Thumbnail: View>: View {
   }
   
   public var body: some View {
-    Button(action: {
-      
-    }) {
-      VStack(spacing: 12) {
-        HStack(alignment: .top, spacing: .zero) {
-          VStack(alignment: .leading, spacing: .zero) {
-            Text(category)
+    VStack(spacing: 12) {
+      HStack(alignment: .top, spacing: .zero) {
+        VStack(alignment: .leading, spacing: .zero) {
+          Text(category)
+            .notoSans(.caption)
+            .foregroundStyle(.primary700)
+            .padding(.bottom, 4)
+          
+          Text(title)
+            .notoSans(.subhead_4)
+            .foregroundStyle(.greyScale900)
+            .padding(.bottom, 8)
+            .lineLimit(2)
+            .multilineTextAlignment(.leading)
+          
+          HStack(alignment: .center, spacing: 6) {
+            Text(platform)
               .notoSans(.caption)
-              .foregroundStyle(.primary700)
-              .padding(.bottom, 4)
+              .foregroundStyle(.greyScale400)
             
-            Text(title)
-              .notoSans(.subhead_4)
+            Circle()
+              .frame(width: 3, height: 3)
               .foregroundStyle(.greyScale900)
-              .padding(.bottom, 8)
-              .lineLimit(2)
-              .multilineTextAlignment(.leading)
             
-            HStack(alignment: .center, spacing: 6) {
-              Text(platform)
-                .notoSans(.caption)
-                .foregroundStyle(.greyScale400)
-              
-              Circle()
-                .frame(width: 3, height: 3)
-                .foregroundStyle(.greyScale900)
-              
-              Text(postDate)
-                .notoSans(.caption)
-                .foregroundStyle(.greyScale400)
-            }
+            Text(postDate)
+              .notoSans(.caption)
+              .foregroundStyle(.greyScale400)
           }
-          .padding(.trailing, 4.88)
-          
-          Spacer(minLength: 18)
-          
-          thumbnailImage
         }
+        .padding(.trailing, 4.88)
         
-        GeometryReader { geometry in
-          Divider()
-            .background(Color(hex: "E1E3E7"))
-            .frame(width: geometry.size.width - 99.12)
-        }
-        .frame(height: 0.5)
+        Spacer(minLength: 18)
+        
+        thumbnailImage
       }
-      .padding(.horizontal, 15.94)
+      
+      GeometryReader { geometry in
+        Divider()
+          .background(Color(hex: "E1E3E7"))
+          .frame(width: geometry.size.width - 99.12)
+      }
+      .frame(height: 0.5)
     }
+    .padding(.horizontal, 15.94)
   }
 }

--- a/Projects/Shared/DesignSystem/Sources/Components/Navigation/TopArticleNavigation.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Navigation/TopArticleNavigation.swift
@@ -11,16 +11,16 @@ public struct TopArticleNavigation: View {
   
   @State private var title: String = ""
   private let leftAction: () -> Void
-  private let rightAction: () -> Void
+  private let url: String
   
   public init(
     title: String,
-    leftAction: @escaping () -> Void,
-    rightAction: @escaping () -> Void
+    url: String,
+    leftAction: @escaping () -> Void
   ) {
     self.title = title
+    self.url = url
     self.leftAction = leftAction
-    self.rightAction = rightAction
   }
   
   public var body: some View {
@@ -32,10 +32,13 @@ public struct TopArticleNavigation: View {
       
       titleContect()
       
-      navigationItem(
-        image: .externalLink,
-        rightAction
-      )
+      ShareLink(item: URL(string: url)!) {
+        Image.externalLink
+          .resizable()
+          .scaledToFit()
+          .frame(width: 24, height: 24)
+          .foregroundStyle(.greyScale950)
+      }
     }
   }
   

--- a/Projects/Shared/DesignSystem/Sources/Components/Navigation/TopArticleNavigation.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Navigation/TopArticleNavigation.swift
@@ -62,6 +62,7 @@ public struct TopArticleNavigation: View {
       )
       .foregroundStyle(Color.init(hex: "A7A7A7"))
       .notoSans(.body_long_1)
+      .disabled(true)
     }
     .padding(.horizontal, 6)
     .padding(.vertical, 4)

--- a/Projects/Shared/DesignSystem/Sources/Components/WebViewRepresentable.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/WebViewRepresentable.swift
@@ -1,0 +1,33 @@
+//
+//  WebViewRepresentable.swift
+//  SharedDesignSystem
+//
+//  Created by 현수빈 on 9/25/24.
+//
+import SwiftUI
+import WebKit
+
+public struct WebViewRepresentable: UIViewRepresentable {
+  var url: String
+  
+  public init(url: String) {
+    self.url = url
+  }
+  
+  public func makeUIView(context: Context) -> WKWebView {
+    guard let url = URL(string: url) else {
+      return WKWebView()
+    }
+    let webView = WKWebView()
+    
+    webView.load(URLRequest(url: url))
+    
+    return webView
+  }
+  
+  public func updateUIView(_ webView: WKWebView, context: UIViewRepresentableContext<WebViewRepresentable>) {
+    guard let url = URL(string: url) else { return }
+    
+    webView.load(URLRequest(url: url))
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #30

## 🛠️ 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 홈에서 아티클 클릭 시 웹뷰를 띄우는 로직을 처리했습니다.
- 어떻게 올라오는지 명시가 되어 있지 않아 현재는 fullScreen Cover로 처리해놨습니다.
- 공유하기는 ShareLink로 처리했습니다.

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/f46936c4-b8e0-4ded-985c-1e5a5ad7f1ae

