### PR TITLE
#67 - 인증서와 프로비저닝 파일 이름 및 bundle identifer 이름 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .AppleDouble
 .LSOverride
 
+fastlane/.env
+
 # Icon must end with two
 Icon
 

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Project+Enviorment.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Project+Templete/Project+Enviorment.swift
@@ -14,9 +14,9 @@ public extension Project {
     public static let appDevName = "OnboardingKit-Dev"
     public static let deploymentTarget : ProjectDescription.DeploymentTargets = .iOS("17.0")
     public static let deploymentDestination: ProjectDescription.Destinations = [.iPhone]
-    public static let organizationTeamId = "2YJXRFH75A"
-    public static let bundlePrefix = "com.DDD.OnboardingKit"
+    public static let organizationTeamId = "H89XC7VZRC"
+    public static let bundlePrefix = "com.DDD.onboarding-kit"
     public static let appVersion = "0.1.0"
-    public static let mainBundleId = "com.DDD.OnboardingKit"
+    public static let mainBundleId = "com.DDD.onboarding-kit"
   }
 }

--- a/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/Project+Settings.swift
+++ b/Plugins/ProjectTemplatePlugin/ProjectDescriptionHelpers/Setting/Project+Settings.swift
@@ -40,7 +40,7 @@ extension Settings {
       .setCodeSignIdentity()
       .setCodeSignStyle()
       .setVersioningSystem()
-      .setProvisioningProfileSpecifier("match AppStore com.DDD.OnboardingKit")
+      .setProvisioningProfileSpecifier("match AppStore com.DDD.onboarding-kit")
       .setDevelopmentTeam(Project.Environment.organizationTeamId)
       .setSkipInstall(true)
       .setDebugInformationFormat(),
@@ -50,7 +50,7 @@ extension Settings {
         settings: commonSettings(
           appName: Project.Environment.appDevName,
           displayName: Project.Environment.appDevName,
-          provisioningProfile: "match Development com.DDD.OnboardingKit"
+          provisioningProfile: "match Development com.DDD.onboarding-kit"
         ),
         xcconfig: "Resources/Config.xcconfig"
       ),
@@ -59,7 +59,7 @@ extension Settings {
         settings: commonSettings(
           appName: Project.Environment.appDemoName,
           displayName: Project.Environment.appDemoName,
-          provisioningProfile: "match AppStore com.DDD.OnboardingKit"
+          provisioningProfile: "match AppStore com.DDD.onboarding-kit"
         ),
         xcconfig: "Resources/Config.xcconfig"
       ),
@@ -68,7 +68,7 @@ extension Settings {
         settings: commonSettings(
           appName: Project.Environment.appName,
           displayName: Project.Environment.appName,
-          provisioningProfile: "match AppStore com.DDD.OnboardingKit"
+          provisioningProfile: "match AppStore com.DDD.onboarding-kit"
         ),
         xcconfig: "Resources/Config.xcconfig"
       )

--- a/Projects/App/Entitlements/OnboardingKit.entitlements
+++ b/Projects/App/Entitlements/OnboardingKit.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)group.com.DDD.OnboardingKit</string>
+		<string>$(AppIdentifierPrefix)group.com.DDD.onboarding-kit</string>
 	</array>
 </dict>
 </plist>

--- a/Projects/Core/Network/Sources/Services/KeyChain/KeychainClient.swift
+++ b/Projects/Core/Network/Sources/Services/KeyChain/KeychainClient.swift
@@ -84,8 +84,8 @@ extension KeychainClient: DependencyKey {
     }
     
     let keychain = Keychain(
-      service: "com.DDD.OnboardingKit",
-      accessGroup: "\(appIdentifierPrefix)group.com.DDD.OnboardingKit"
+      service: "com.DDD.onboarding-kit",
+      accessGroup: "\(appIdentifierPrefix)group.com.DDD.onboarding-kit"
     )
     
     return Self(

--- a/fastlane/.env
+++ b/fastlane/.env
@@ -1,3 +1,0 @@
-APP_IDENTIFIER="com.DDD.OnboardingKit"
-APPLE_ID="sunny5875@naver.com"
-TEAM_ID="2YJXRFH75A"

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("git@github.com:sunny5875/DDD11-SClass-iOS-Match.git")
+git_url("https://github.com/sunny5875/DDD11-SClass-iOS-Match.git")
 storage_mode("git")
 platform("ios")
 app_identifier([ENV["APP_IDENTIFIER"]])


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #67

## 🛠️ 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 애플 개발자 계정이 변경되어서 이에 따른 프로젝트 세팅값을 바꿨습니다!
- match repo를 업데이트했습니다!
- 노션에 관련된 계정 정보가 적혀있으니(fastlane/.env파일 업데이트 필요) 혹시 인증서가 다운로드되지 않는다면 한번 보시면 될 것 같습니다!!

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 저희가 지난 신입키트를 베타 테스팅에 올리었다보니 이로 인해 신입키트라는 앱이름을 사용하지 못하게 될 거 같습니다 어떻게 하면 좋을까요!! 의견 부탁드립니다
